### PR TITLE
Fix reprendre epreuve

### DIFF
--- a/contestInterface/common.js
+++ b/contestInterface/common.js
@@ -1698,7 +1698,7 @@ function loadSession() {
       function(data) {
          SID = data.SID;
          if (data.teamID) {
-            if (!confirm("Voulez-vous reprendre l'épreuve commencée ?")) { // t("restart_previous_contest") json not loaded yet!
+            if (!confirm(t("restart_previous_contest"))) { // was fixed string "Voulez-vous reprendre l'épreuve commencée ?"
                destroySession();
                return;
             }

--- a/contestInterface/i18n/nl/be.json
+++ b/contestInterface/i18n/nl/be.json
@@ -9,7 +9,7 @@
     "closed_connexion_error": "<p><b>Opgelet</b>, omwille van een probleem met de verbinding konden sommige antwoorden niet verzonden worden. Sla de onderstaande tekst op en stuur hem per e-mail door naar info@be-oi.be zodra je de kans hebt, zodat je antwoorden in rekening gebracht kunnen worden.</p><p><b>Maak geen screenshot of foto</b>. Plak de tekst direct in je email, of in een tekstbestand dat je ons opstuurt:</p>",
     "closed_announcement": "<p>Je zal dan kunnen weten of je geselecteerd bent voor de <a href='https://beoi.be-oi.be'>beOI</a> finale. Er zijn veel prijzen te winnen.</p><p>Voor wie al kan programmeren, kijk snel ook naar de <a href='https://becp.be-oi.be/'>beCP</a> wedstrijd en kwalificeer jezelf voor internationale wedstrijden.</p>",
     "contest_starts_now_full_feedback": "Start! Merk linksboven je score op die zich aanpast naargelang je antwoorden!",
-    "restart_previous_contest": "Wil je de begonnen proef herstarten?",
+    "restart_previous_contest": "Wil je de begonnen proef verderzetten?",
     "confirm_leave_question": "Ben je zeker dat je van vraag wil wisselen? Je antwoord is niet opgeslagen en zal verloren gaan.",
     "contest_load_failure": "De wedstrijd is niet correct geïnitialiseerd. Herlaad aub de pagina.",
     "error_reloading_iframe": "Sorry, we kunnen de iframe niet herladen. Als er een probleem is voorgevallen, selecteer dan een andere vraag en kom later terug naar deze.",

--- a/contestInterface/i18n/nl/translation.json
+++ b/contestInterface/i18n/nl/translation.json
@@ -68,7 +68,7 @@
     "time_is_up": "De tijd is om. Bedankt voor je deelname!",
     "contest_starts_now": "Start! Merk rechtsboven goed op hoeveel punten je kan winnen of verliezen met elke vraag.",
     "contest_starts_now_full_feedback": "Start! Merk linksboven je score op die zich aanpast naargelang je antwoorden!",
-    "restart_previous_contest": "Wil je de begonnen proef hernemen?",
+    "restart_previous_contest": "Wil je de begonnen proef verderzetten?",
     "confirm_leave_question": "Ben je zeker dat je van vraag wil wisselen? Je antwoord is niet opgeslagen en zal verloren gaan.",
     "contest_load_failure": "De wedstrijd is niet correct geïnitialiseerd. Herlaad aub de pagina.",
     "error_reloading_iframe": "Sorry, we kunnen de iframe niet herladen. Als er een probleem is voorgevallen, selecteer dan een andere vraag en kom later terug naar deze.",


### PR DESCRIPTION
Replaced this hardcoded string, translations were already done. Updated NL translation to better convey the exact meaning (continue, not restart).