### PR TITLE
Fix addresses for subscribing to the platform

### DIFF
--- a/teacherInterface/i18n/fr/be.json
+++ b/teacherInterface/i18n/fr/be.json
@@ -30,9 +30,9 @@
     "invalid_officialEmail": "Votre adresse officielle est invalide. Ne saisissez pas le @ac-… dans la zone de gauche.",
     "one_email_required": "Vous devez fournir au moins une adresse électronique, si possible une adresse officielle.",
     "officialEmail_readonly": "Impossible de changer d'adresse officielle une fois celle-ci confirmée",
-    "you_will_get_email": "Vous allez recevoir un courrier électronique sur votre adresse officielle avec lequel vous allez pouvoir valider votre compte.<br/><br/>Vérifiez bien qu'il n'est pas classé comme indésirable.<br/><br/>Si vous ne recevez aucun courriel dans les 2h, contactez info@be-oi.be depuis votre adresse académique pour que nous validions votre compte.",
+    "you_will_get_email": "Vous allez recevoir un courrier électronique sur votre adresse officielle avec lequel vous allez pouvoir valider votre compte.<br/><br/>Vérifiez bien qu'il n'est pas classé comme indésirable.<br/><br/>Si vous ne recevez aucun courriel dans les 2h, contactez inscription@be-oi.be depuis votre adresse académique pour que nous validions votre compte.",
     "no_official_email_1": "Vous n'avez pas fourni d'adresse officielle, donc votre compte ne peut être validé que par un administrateur. N'oubliez pas de ",
-    "contact_us": "contactez-nous par e-mail à info@be-oi.be",
+    "contact_us": "contactez-nous par e-mail à inscription@be-oi.be",
     "mail_from_name": "Inscription beOI",
     "recover_mail_body": "Bonjour,\r\n\r\nPour définir un nouveau mot de passe, ouvrez le lien suivant dans votre navigateur  : \r\n\r\n__link__\r\n\r\nN'hésitez pas à nous contacter si vous rencontrez des difficultés.\r\n\r\nCordialement,\r\n--\r\nL'équipe beOI",
     "email_body_no_official_email": "...",
@@ -98,7 +98,7 @@
     "validationMailBody": "Bonjour,\r\n\r\nPour valider votre inscription en tant que coordinateur pour le concours beOI, ouvrez le lien suivant dans votre navigateur  : \r\n\r\n%s\r\n\r\nN'hésitez pas à nous contacter si vous rencontrez des difficultés.\r\n\r\nCordialement,\r\n-- \r\nL'équipe beOI",
     "validationMailTitle": "Éliminatoires beOI : Confirmation d'inscription",
 
-    "manualValidationMailBody": "Bonjour,\r\n\r\nMerci pour votre inscription en tant que coordinateur au concours beOI. Vu que votre adresse e-mail officielle n'appartient pas aux domaines reconnus, nous vous demandons de nous envoyer un e-mail avec cette même adresse à info@beo-oi.be (ou de simplement répondre à cet e-mail) en mentionnant votre établissement, son site web et votre rôle au sein de l'établissement.\r\nNous vérifierons ces données et vous validerons votre inscription dans les plus brefs délais.\r\n\r\nCordialement,\r\n-- \r\nL'équipe beOI",
+    "manualValidationMailBody": "Bonjour,\r\n\r\nMerci pour votre inscription en tant que coordinateur au concours beOI. Vu que votre adresse e-mail officielle n'appartient pas aux domaines reconnus, nous vous demandons de nous envoyer un e-mail avec cette même adresse à inscription@be-oi.be (ou de simplement répondre à cet e-mail) en mentionnant votre établissement, son site web et votre rôle au sein de l'établissement.\r\nNous vérifierons ces données et vous validerons votre inscription dans les plus brefs délais.\r\n\r\nCordialement,\r\n-- \r\nL'équipe beOI",
     "manualValidationMailTitle": "Éliminatoires beOI : Confirmation d'inscription",
 
     "emailNotValidatedError": "Vos identifiants sont valides mais votre adresse e-mail officielle n'a pas encore été validée. Vous avez dû recevoir un mail après votre inscription, vérifiez éventuellement dans les courriers indésirables de votre boîte mail. Si vous n'avez rien reçu, contactez-nous : ",

--- a/teacherInterface/i18n/nl/be.json
+++ b/teacherInterface/i18n/nl/be.json
@@ -30,9 +30,9 @@
     "invalid_officialEmail": "Uw officieel emailadres is ongeldig. Vergeet de @ac-… niet in de zone links.",
     "one_email_required": "U moet minstens één emailadres opgeven, indien mogelijk een officieel adres.",
     "officialEmail_readonly": "Het is niet mogelijk het officieel emailadres te veranderen eens het is bevestigd",
-    "you_will_get_email": "U zult een email ontvangen op uw officieel adres waarmee u uw account kunt bevestigen.<br/><br/>Controleer dat deze email niet bij de spam terechtgekomen is.<br/><br/>Volg de link in die mail om uw account te valideren; nadien kunt u inloggen.<br/><br/>Als u geen email ontvangt binnen de 2u, contacteer dan info@be-oi.be vanaf uw officieel emailadres zodat wij uw account kunnen valideren.",
+    "you_will_get_email": "U zult een email ontvangen op uw officieel adres waarmee u uw account kunt bevestigen.<br/><br/>Controleer dat deze email niet bij de spam terechtgekomen is.<br/><br/>Volg de link in die mail om uw account te valideren; nadien kunt u inloggen.<br/><br/>Als u geen email ontvangt binnen de 2u, contacteer dan inschrijving@be-oi.be vanaf uw officieel emailadres zodat wij uw account kunnen valideren.",
     "no_official_email_1": "U heeft geen officieel emailadres opgegeven, dus uw account kan enkel door een administrator worden gevalideerd. Vergeet niet om ",
-    "contact_us": "contacteer ons via email naar info@be-oi.be",
+    "contact_us": "contacteer ons via email naar inschrijving@be-oi.be",
     "mail_from_name": "Inschrijving voor beOI",
     "recover_mail_body": "Hallo, \r\n\r\nOm een nieuw paswoord aan te maken, open de volgende link in uw browser:  \r\n\r\n__link__\r\n\r\nAarzel niet om ons te contacteren als u problemen tegenkomt. \r\n\r\nMet vriendelijke groeten,\r\n--\r\nHet team achter beOI",
     "email_body_no_official_email": "...",
@@ -98,7 +98,7 @@
     "validationMailBody": "Hallo,\r\n\r\nOm uw inschrijving als coördinator voor de beOI-wedstrijd te valideren, opent u de volgende link in uw browser: \r\n\r\n%s\r\n\r\nAarzel niet om ons te contacteren als u problemen ondervindt.\r\n\r\nMet vriendelijke groeten,\r\n-- \r\nHet beOI-team",
     "validationMailTitle": "Eerste ronde beOI : Bevestiging van inschrijving",
 
-    "manualValidationMailBody": "Hallo,\r\n\r\nBedankt voor uw inschrijving als coördinator voor de beOI-wedstrijd. Omdat het domein van uw officieel emailadres nog niet in onze lijst voorkomt, vragen wij u om een email te sturen vanaf hetzelfde adres naar info@be-oi.be (of eenvoudigweg deze email te beantwoorden) met vermelding van uw school, haar website en uw rol in de school.\r\nWij bevestigen deze gegevens dan manueel en valideren uw inschrijving zo snel mogelijk.\r\n\r\nMet vriendelijke groeten,\r\n-- \r\nHet beOI-team",
+    "manualValidationMailBody": "Hallo,\r\n\r\nBedankt voor uw inschrijving als coördinator voor de beOI-wedstrijd. Omdat het domein van uw officieel emailadres nog niet in onze lijst voorkomt, vragen wij u om een email te sturen vanaf hetzelfde adres naar inschrijving@be-oi.be (of eenvoudigweg deze email te beantwoorden) met vermelding van uw school, haar website en uw rol in de school.\r\nWij bevestigen deze gegevens dan manueel en valideren uw inschrijving zo snel mogelijk.\r\n\r\nMet vriendelijke groeten,\r\n-- \r\nHet beOI-team",
     "manualValidationMailTitle": "Eerste ronde beOI : Bevestiging van inschrijving",
 
     "emailNotValidatedError": "Uw gegevens zijn geldig maar uw officieel emailadres is nog niet gevalideerd. U zou daarvoor een email gekregen moeten hebben na uw inschrijving, kijk eventueel na of deze niet bij de ongewenste email is beland. Indien u niets heeft ontvangen, contacteer ons: ",


### PR DESCRIPTION
Replace info@be-oi.be by inscription@be-oi.be or inschrijving@be-oi.be.